### PR TITLE
add check ownership function

### DIFF
--- a/contracts/mpc721/src/contract.rs
+++ b/contracts/mpc721/src/contract.rs
@@ -7,11 +7,11 @@ use mpc721_base::{
     actions::{
         execute_approve, execute_approve_for_all, execute_burn, execute_init, execute_mint,
         execute_revoke, execute_revoke_for_all, execute_set_base_uri, execute_transfer,
-        execute_transfer_from,
+        execute_transfer_from,execute_ownership_check
     },
     msg::{
         ApproveForAllMsg, ApproveMsg, BurnMsg, InitMsg, MintMsg, RevokeForAllMsg, RevokeMsg,
-        SetBaseUriMsg, TransferFromMsg, TransferMsg,
+        SetBaseUriMsg, TransferFromMsg, TransferMsg,CheckOwnerMsg
     },
 };
 
@@ -153,5 +153,17 @@ pub fn burn(
     let mut state = state;
     let events = execute_burn(&ctx, &mut state.mpc721, &BurnMsg { token_id });
 
+    (state, events)
+}
+
+#[action(shortname = 0x18)]
+pub fn check_ownership(
+    ctx: ContractContext,
+    state: ContractState,
+    owner: Address,
+    token_id: u128,    
+) -> (ContractState, Vec<EventGroup>) {
+    let mut state = state;
+    let events=execute_ownership_check(&ctx, &mut state.mpc721, &CheckOwnerMsg {owner, token_id });
     (state, events)
 }

--- a/packages/mpc721-base/src/actions.rs
+++ b/packages/mpc721-base/src/actions.rs
@@ -4,10 +4,10 @@ use pbc_contract_common::{context::ContractContext, events::EventGroup};
 
 use crate::{
     msg::{
-        ApproveForAllMsg, ApproveMsg, BurnMsg, InitMsg, MintMsg, RevokeForAllMsg, RevokeMsg,
-        SetBaseUriMsg, TransferFromMsg, TransferMsg,
+        ApproveForAllMsg, ApproveMsg, BurnMsg, CheckOwnerMsg, InitMsg, MintMsg, RevokeForAllMsg,
+        RevokeMsg, SetBaseUriMsg, TransferFromMsg, TransferMsg,
     },
-    state::MPC721ContractState,
+    state::{MPC721ContractState},
     ContractError,
 };
 
@@ -233,5 +233,31 @@ pub fn execute_burn(
     state.remove_token(&ctx.sender, msg.token_id);
     state.decrease_supply();
 
+    vec![]
+}
+/// ## Description
+/// Check if a user owns a particular token. Will revert otherwise
+/// Returns [`(MPC721ContractState, Vec<EventGroup>)`] if operation was successful,
+/// otherwise panics with error message defined in [`ContractError`]
+/// ## Params
+/// * **ctx** is an object of type [`ContractContext`]
+///
+/// * **state** is an object of type [`MPC721ContractState`]
+///
+/// * **msg** is an object of type [`CheckOwnerMsg`]
+pub fn execute_ownership_check(
+    ctx: &ContractContext,
+    state: &mut MPC721ContractState,
+    msg: &CheckOwnerMsg,
+) -> Vec<EventGroup> {
+    let token_info = state.token_info(msg.token_id);
+    match token_info {
+        Some(_) => assert!(
+            token_info.unwrap().owner == msg.owner,
+            "{}",
+            ContractError::IncorrectOwner
+        ),
+        None => panic!("{}", ContractError::NotFound),
+    };
     vec![]
 }

--- a/packages/mpc721-base/src/error.rs
+++ b/packages/mpc721-base/src/error.rs
@@ -12,4 +12,7 @@ pub enum ContractError {
 
     #[error("Not found")]
     NotFound,
+
+    #[error("Token ownership check failed")]
+    IncorrectOwner,
 }

--- a/packages/mpc721-base/src/msg.rs
+++ b/packages/mpc721-base/src/msg.rs
@@ -264,3 +264,30 @@ impl IntoShortnameRPCEvent for BurnMsg {
             .done();
     }
 }
+
+/// ## Description
+/// This structure describes fields for mpc721 check owner msg
+#[derive(ReadWriteRPC, CreateTypeSpec, Clone, PartialEq, Eq, Debug)]
+pub struct CheckOwnerMsg {
+    /// receiver address
+    pub owner: Address,
+    /// token id
+    pub token_id: u128,
+}
+impl IntoShortnameRPCEvent for CheckOwnerMsg {
+    fn action_shortname(&self) -> u32 {
+        0x18
+    }
+
+    fn as_interaction(
+        &self,
+        builder: &mut pbc_contract_common::events::EventGroupBuilder,
+        dest: &Address,
+    ) {
+        builder
+            .call(*dest, Shortname::from_u32(self.action_shortname()))
+            .argument(self.owner)
+            .argument(self.token_id)
+            .done();
+    }
+}


### PR DESCRIPTION
Adds a new function that allows contracts to check if a user owns an MPC721NFT then execute a callback accordingly